### PR TITLE
Add `createdb test` to bin/setup + use distinctive db name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           PGUSER: postgres
         run: |
           sudo apt-get -yqq install libpq-dev
-          psql -U postgres -c "create database test"
+          psql -U postgres -c "create database ar_enum_test"
 
       - name: Install gem dependencies
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - sudo mv postgresql.conf /etc/postgresql/11/main
   - sudo service postgresql start 11
 before_script:
-  - createdb test
+  - createdb ar_enum_test
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - "./cc-test-reporter before-build"

--- a/bin/setup
+++ b/bin/setup
@@ -6,6 +6,4 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
-createdb test
-
-# Do any other automated setup that you need to do here
+createdb ar_enum_test

--- a/bin/setup
+++ b/bin/setup
@@ -6,5 +6,6 @@ IFS=$'\n\t'
 set -vx
 
 bundle install
+createdb test
 
 # Do any other automated setup that you need to do here

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -2,7 +2,7 @@
 
 require "active_record"
 
-ActiveRecord::Base.establish_connection "postgres:///test"
+ActiveRecord::Base.establish_connection "postgres:///ar_enum_test"
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Base.logger = nil
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ require "ar/enum"
 require "minitest/utils"
 require "minitest/autorun"
 
-ActiveRecord::Base.establish_connection "postgres:///test"
+ActiveRecord::Base.establish_connection "postgres:///ar_enum_test"
 ActiveRecord::Migration.verbose = false
 
 class Article < ActiveRecord::Base


### PR DESCRIPTION
Hello,

As i contributed to the project, I wish that it automatically created the test db for me, so I added this step to `bin/setup`.

I then realized that the name "test" was a bit too common for a db name, so I decided to change it so it would not conflit with another project for example.