### PR TITLE
Sort enums by name in schema.rb

### DIFF
--- a/lib/ar/enum/schema_dumper.rb
+++ b/lib/ar/enum/schema_dumper.rb
@@ -9,7 +9,7 @@ module AR
       end
 
       def enum_types(stream)
-        list = @connection.enum_types.to_a
+        list = @connection.enum_types.to_a.sort_by { |type| type["name"] }
 
         stream.puts("  # These are enum types available on this database") if list.any?
 

--- a/test/ar/enum_test.rb
+++ b/test/ar/enum_test.rb
@@ -261,11 +261,13 @@ class EnumTest < Minitest::Test
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
     contents = stream.tap(&:rewind).read
 
-    assert_includes(
-      contents,
-      %{create_enum :article_status, ["draft", "unlisted", "published"]}
-    )
-    assert_includes contents, %{create_enum :color, ["blue", "green", "yellow"]}
+    enum_section = <<-RUBY
+  # These are enum types available on this database
+  create_enum :article_status, ["draft", "unlisted", "published"]
+  create_enum :color, ["blue", "green", "yellow"]
+    RUBY
+    assert_includes contents, enum_section
+
     assert_includes contents, %[create_table "articles"]
     assert_includes contents, %[t.article_status "status"]
     assert_includes contents, %[t.color "background"]


### PR DESCRIPTION
Hello,

The order of the enums in `schema.rb` tends to be non-deterministic between my co-workers and me, so what would you think of having them sorted alphabetically?

As far as I understand, this has no impact in terms of behaviour.