### PR TITLE
Use an object to manipulate enums found in db

### DIFF
--- a/lib/ar/enum.rb
+++ b/lib/ar/enum.rb
@@ -28,10 +28,10 @@ ActiveSupport.on_load(:active_record) do
       def create_table_definition(*args)
         ActiveRecord::Base.connection.enum_types.each do |enum|
           ActiveRecord::ConnectionAdapters::PostgreSQL::ColumnMethods.class_eval do
-            ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[enum["name"].to_sym] = {name: enum["name"]}
+            ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[enum.name.to_sym] = {name: enum.name}
 
-            define_method(enum["name"]) do |*names, **options|
-              names.each {|name| column(name, enum["name"].to_sym, options) }
+            define_method(enum.name) do |*names, **options|
+              names.each {|name| column(name, enum.name.to_sym, options) }
             end
           end
         end

--- a/lib/ar/enum/schema_dumper.rb
+++ b/lib/ar/enum/schema_dumper.rb
@@ -5,22 +5,19 @@ module AR
     module SchemaDumper
       def header(stream)
         super
-        enum_types(stream)
+        enum_section(stream)
       end
 
-      def enum_types(stream)
-        list = @connection.enum_types.to_a
+      def enum_section(stream)
+        list = @connection.enum_types
 
         stream.puts("  # These are enum types available on this database") if list.any?
 
-        list.each do |row|
-          labels = row["labels"].split(",")
-          name = row["name"].to_sym
-
+        list.each do |enum_in_db|
           statement = [
             "  create_enum",
-            "#{name.inspect},",
-            labels.inspect
+            "#{enum_in_db.name.to_sym.inspect},",
+            enum_in_db.labels.inspect
           ].join(" ")
 
           stream.puts(statement)

--- a/test/ar/enum_test.rb
+++ b/test/ar/enum_test.rb
@@ -12,11 +12,11 @@ class EnumTest < Minitest::Test
 
   def enum_labels(name)
     result = ActiveRecord::Base.connection.enum_types
-    entry = result.find {|row| row["name"] == name.to_s }
+    enum_in_db = result.find {|row| row.name == name.to_s }
 
-    return [] unless entry
+    return [] unless enum_in_db
 
-    entry["labels"].split(",")
+    enum_in_db.labels
   end
 
   test "adds enum" do
@@ -287,11 +287,11 @@ class EnumTest < Minitest::Test
       end
     end
 
-    assert_equal 0, ActiveRecord::Base.connection.enum_types.to_a.size
+    assert_equal 0, ActiveRecord::Base.connection.enum_types.size
 
     migrations.each {|migration| migration.migrate(:up) }
 
-    assert_equal 2, ActiveRecord::Base.connection.enum_types.to_a.size
+    assert_equal 2, ActiveRecord::Base.connection.enum_types.size
 
     stream = StringIO.new
     ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, stream)
@@ -299,11 +299,11 @@ class EnumTest < Minitest::Test
 
     migrations.each {|migration| migration.migrate(:down) }
 
-    assert_equal 0, ActiveRecord::Base.connection.enum_types.to_a.size
+    assert_equal 0, ActiveRecord::Base.connection.enum_types.size
 
     eval(contents) # rubocop:disable Security/Eval
 
-    assert_equal 2, ActiveRecord::Base.connection.enum_types.to_a.size
+    assert_equal 2, ActiveRecord::Base.connection.enum_types.size
 
     assert_equal %i[article_status color integer],
                  Article.columns.map(&:type).sort


### PR DESCRIPTION
Hello,

While contributing to the project, I found myself wishing to manipulate an object instead of a Hash or a String of comma-separated list of labels. 

This PR introduces the tiny `EnumInDb` class, which has two methods :

- `#name` -> String
- `#labels` -> Array<String>

This allows for a more concise style, for example : 

```ruby
# this
entry["labels"].split(",")

# becomes this
enum_in_db.labels
```

I know that this is my style of Ruby, so I understand if you don't think it is an improvement. Tell me what you think! :upside_down_face: 